### PR TITLE
chore: use camel case instead of snake case

### DIFF
--- a/bytes_cache.go
+++ b/bytes_cache.go
@@ -28,35 +28,35 @@ func NewBytesCache(shards uint8, shardsize uint32) *BytesCache {
 
 // Get returns value for key.
 func (c *BytesCache) Get(key []byte) (value []byte, ok bool) {
-	hash := uint32(wyhash_HashBytes(key, 0))
+	hash := uint32(wyhashHashbytes(key, 0))
 	// return c.shards[hash&c.mask].Get(hash, key)
 	return (*bytesshard)(unsafe.Add(unsafe.Pointer(&c.shards[0]), uintptr(hash&c.mask)*unsafe.Sizeof(c.shards[0]))).Get(hash, key)
 }
 
 // Peek returns value, but does not modify its recency.
 func (c *BytesCache) Peek(key []byte) (value []byte, ok bool) {
-	hash := uint32(wyhash_HashBytes(key, 0))
+	hash := uint32(wyhashHashbytes(key, 0))
 	// return c.shards[hash&c.mask].Peek(hash, key)
 	return (*bytesshard)(unsafe.Add(unsafe.Pointer(&c.shards[0]), uintptr(hash&c.mask)*unsafe.Sizeof(c.shards[0]))).Peek(hash, key)
 }
 
 // Set inserts key value pair and returns previous value.
 func (c *BytesCache) Set(key []byte, value []byte) (prev []byte, replaced bool) {
-	hash := uint32(wyhash_HashBytes(key, 0))
+	hash := uint32(wyhashHashbytes(key, 0))
 	// return c.shards[hash&c.mask].Set(hash, key, value)
 	return (*bytesshard)(unsafe.Add(unsafe.Pointer(&c.shards[0]), uintptr(hash&c.mask)*unsafe.Sizeof(c.shards[0]))).Set(hash, key, value)
 }
 
 // SetIfAbsent inserts key value pair and returns previous value, if key is absent in the cache.
 func (c *BytesCache) SetIfAbsent(key []byte, value []byte) (prev []byte, replaced bool) {
-	hash := uint32(wyhash_HashBytes(key, 0))
+	hash := uint32(wyhashHashbytes(key, 0))
 	// return c.shards[hash&c.mask].SetIfAbsent(hash, key, value)
 	return (*bytesshard)(unsafe.Add(unsafe.Pointer(&c.shards[0]), uintptr(hash&c.mask)*unsafe.Sizeof(c.shards[0]))).SetIfAbsent(hash, key, value)
 }
 
 // Delete method deletes value associated with key and returns deleted value (or empty value if key was not in cache).
 func (c *BytesCache) Delete(key []byte) (prev []byte) {
-	hash := uint32(wyhash_HashBytes(key, 0))
+	hash := uint32(wyhashHashbytes(key, 0))
 	// return c.shards[hash&c.mask].Delete(hash, key)
 	return (*bytesshard)(unsafe.Add(unsafe.Pointer(&c.shards[0]), uintptr(hash&c.mask)*unsafe.Sizeof(c.shards[0]))).Delete(hash, key)
 }
@@ -83,16 +83,16 @@ func (c *BytesCache) Stats() (stats Stats) {
 	for i := uint32(0); i <= c.mask; i++ {
 		s := &c.shards[i]
 		s.mu.Lock()
-		stats.EntriesCount += uint64(s.table_length)
-		stats.GetCalls += s.stats_getcalls
-		stats.SetCalls += s.stats_setcalls
-		stats.Misses += s.stats_misses
+		stats.EntriesCount += uint64(s.tableLength)
+		stats.GetCalls += s.statsGetCalls
+		stats.SetCalls += s.statsSetCalls
+		stats.Misses += s.statsMisses
 		s.mu.Unlock()
 	}
 	return
 }
 
-func wyhash_HashBytes(data []byte, seed uint64) uint64 {
+func wyhashHashbytes(data []byte, seed uint64) uint64 {
 	if len(data) == 0 {
 		return seed
 	}

--- a/bytes_cache_test.go
+++ b/bytes_cache_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestBytesCacheDefaultkey(t *testing.T) {
+func TestBytesCacheDefaultKey(t *testing.T) {
 	cache := NewBytesCache(1, 1)
 	var k []byte
 	var i = []byte("42")

--- a/bytes_shard.go
+++ b/bytes_shard.go
@@ -20,44 +20,44 @@ type bytesbucket struct {
 	index uint32 // node index
 }
 
-// bytesshard is a LRU partition contains a list and a hash table.
+// bytesshard is an LRU partition contains a list and a hash table.
 type bytesshard struct {
 	mu sync.Mutex
 
-	// the hash table, with 20% extra space than the list for fewer conflicts.
-	table_buckets []uint64 // []bytesbucket
-	table_mask    uint32
-	table_length  uint32
+	// the hash table, with 20% extra spacer than the list for fewer conflicts.
+	tableBuckets []uint64 // []bytesbucket
+	tableMask    uint32
+	tableLength  uint32
 
 	// the list of nodes
 	list []bytesnode
 
 	// stats
-	stats_getcalls uint64
-	stats_setcalls uint64
-	stats_misses   uint64
+	statsGetCalls uint64
+	statsSetCalls uint64
+	statsMisses   uint64
 
 	// padding
 	_ [40]byte
 }
 
 func (s *bytesshard) Init(size uint32) {
-	s.list_Init(size)
-	s.table_Init(size)
+	s.listInit(size)
+	s.tableInit(size)
 }
 
 func (s *bytesshard) Get(hash uint32, key []byte) (value []byte, ok bool) {
 	s.mu.Lock()
 
-	s.stats_getcalls++
+	s.statsGetCalls++
 
-	if index, exists := s.table_Get(hash, key); exists {
-		s.list_MoveToFront(index)
+	if index, exists := s.tableGet(hash, key); exists {
+		s.listMoveToFront(index)
 		// value = s.list[index].value
 		value = (*bytesnode)(unsafe.Add(unsafe.Pointer(&s.list[0]), uintptr(index)*unsafe.Sizeof(s.list[0]))).value
 		ok = true
 	} else {
-		s.stats_misses++
+		s.statsMisses++
 	}
 
 	s.mu.Unlock()
@@ -68,7 +68,7 @@ func (s *bytesshard) Get(hash uint32, key []byte) (value []byte, ok bool) {
 func (s *bytesshard) Peek(hash uint32, key []byte) (value []byte, ok bool) {
 	s.mu.Lock()
 
-	if index, exists := s.table_Get(hash, key); exists {
+	if index, exists := s.tableGet(hash, key); exists {
 		value = s.list[index].value
 		ok = true
 	}
@@ -81,25 +81,25 @@ func (s *bytesshard) Peek(hash uint32, key []byte) (value []byte, ok bool) {
 func (s *bytesshard) SetIfAbsent(hash uint32, key []byte, value []byte) (prev []byte, replaced bool) {
 	s.mu.Lock()
 
-	if index, exists := s.table_Get(hash, key); exists {
+	if index, exists := s.tableGet(hash, key); exists {
 		prev = s.list[index].value
 		s.mu.Unlock()
 		return
 	}
 
-	s.stats_setcalls++
+	s.statsSetCalls++
 
 	// index := s.list_Back()
 	// node := &s.list[index]
 	index := s.list[0].prev
 	node := (*bytesnode)(unsafe.Add(unsafe.Pointer(&s.list[0]), uintptr(index)*unsafe.Sizeof(s.list[0])))
 	evictedValue := node.value
-	s.table_Delete(uint32(wyhash_HashBytes(node.key, 0)), node.key)
+	s.tableDelete(uint32(wyhashHashbytes(node.key, 0)), node.key)
 
 	node.key = key
 	node.value = value
-	s.table_Set(hash, key, index)
-	s.list_MoveToFront(index)
+	s.tableSet(hash, key, index)
+	s.listMoveToFront(index)
 	prev = evictedValue
 
 	s.mu.Unlock()
@@ -109,13 +109,13 @@ func (s *bytesshard) SetIfAbsent(hash uint32, key []byte, value []byte) (prev []
 func (s *bytesshard) Set(hash uint32, key []byte, value []byte) (prev []byte, replaced bool) {
 	s.mu.Lock()
 
-	s.stats_setcalls++
+	s.statsSetCalls++
 
-	if index, exists := s.table_Get(hash, key); exists {
+	if index, exists := s.tableGet(hash, key); exists {
 		// node := &s.list[index]
 		node := (*bytesnode)(unsafe.Add(unsafe.Pointer(&s.list[0]), uintptr(index)*unsafe.Sizeof(s.list[0])))
 		previousValue := node.value
-		s.list_MoveToFront(index)
+		s.listMoveToFront(index)
 		node.value = value
 		prev = previousValue
 		replaced = true
@@ -129,12 +129,12 @@ func (s *bytesshard) Set(hash uint32, key []byte, value []byte) (prev []byte, re
 	index := s.list[0].prev
 	node := (*bytesnode)(unsafe.Add(unsafe.Pointer(&s.list[0]), uintptr(index)*unsafe.Sizeof(s.list[0])))
 	evictedValue := node.value
-	s.table_Delete(uint32(wyhash_HashBytes(node.key, 0)), node.key)
+	s.tableDelete(uint32(wyhashHashbytes(node.key, 0)), node.key)
 
 	node.key = key
 	node.value = value
-	s.table_Set(hash, key, index)
-	s.list_MoveToFront(index)
+	s.tableSet(hash, key, index)
+	s.listMoveToFront(index)
 	prev = evictedValue
 
 	s.mu.Unlock()
@@ -144,12 +144,12 @@ func (s *bytesshard) Set(hash uint32, key []byte, value []byte) (prev []byte, re
 func (s *bytesshard) Delete(hash uint32, key []byte) (v []byte) {
 	s.mu.Lock()
 
-	if index, exists := s.table_Get(hash, key); exists {
+	if index, exists := s.tableGet(hash, key); exists {
 		node := &s.list[index]
 		value := node.value
-		s.list_MoveToBack(index)
+		s.listMoveToBack(index)
 		node.value = v
-		s.table_Delete(hash, key)
+		s.tableDelete(hash, key)
 		v = value
 	}
 
@@ -161,7 +161,7 @@ func (s *bytesshard) Delete(hash uint32, key []byte) (v []byte) {
 func (s *bytesshard) Len() (n uint32) {
 	s.mu.Lock()
 	// inlining s.table_Len()
-	n = s.table_length
+	n = s.tableLength
 	s.mu.Unlock()
 
 	return
@@ -169,7 +169,7 @@ func (s *bytesshard) Len() (n uint32) {
 
 func (s *bytesshard) AppendKeys(dst [][]byte) [][]byte {
 	s.mu.Lock()
-	for _, bucket := range s.table_buckets {
+	for _, bucket := range s.tableBuckets {
 		b := (*bytesbucket)(unsafe.Pointer(&bucket))
 		if b.index == 0 {
 			continue

--- a/bytes_shard_list.go
+++ b/bytes_shard_list.go
@@ -6,7 +6,7 @@ import (
 	"unsafe"
 )
 
-func (s *bytesshard) list_Init(size uint32) {
+func (s *bytesshard) listInit(size uint32) {
 	size += 1
 	if len(s.list) == 0 {
 		s.list = make([]bytesnode, size)
@@ -17,11 +17,11 @@ func (s *bytesshard) list_Init(size uint32) {
 	}
 }
 
-func (s *bytesshard) list_Back() uint32 {
+func (s *bytesshard) listBack() uint32 {
 	return s.list[0].prev
 }
 
-func (s *bytesshard) list_MoveToFront(i uint32) {
+func (s *bytesshard) listMoveToFront(i uint32) {
 	root := &s.list[0]
 	if root.next == i {
 		return
@@ -40,7 +40,7 @@ func (s *bytesshard) list_MoveToFront(i uint32) {
 	((*bytesnode)(unsafe.Add(base, uintptr(nodei.next)*unsafe.Sizeof(s.list[0])))).prev = i
 }
 
-func (s *bytesshard) list_MoveToBack(i uint32) {
+func (s *bytesshard) listMoveToBack(i uint32) {
 	j := s.list[0].prev
 	if i == j {
 		return

--- a/bytes_shard_test.go
+++ b/bytes_shard_test.go
@@ -19,11 +19,11 @@ func TestBytesShardListSet(t *testing.T) {
 
 	key := []byte("foobar")
 	value := []byte("42")
-	hash := uint32(wyhash_HashBytes(key, 0))
+	hash := uint32(wyhashHashbytes(key, 0))
 
 	s.Set(hash, key, value)
 
-	if index := s.list_Back(); string(s.list[index].key) == string(key) {
+	if index := s.listBack(); string(s.list[index].key) == string(key) {
 		t.Errorf("foobar should be list back: %v %s", index, s.list[index].key)
 	}
 }
@@ -34,11 +34,11 @@ func TestBytesShardTableSet(t *testing.T) {
 
 	key := []byte("foobar")
 	value := []byte("42")
-	hash := uint32(wyhash_HashBytes(key, 0))
+	hash := uint32(wyhashHashbytes(key, 0))
 
 	s.Set(hash, key, value)
 
-	i, ok := s.table_Set(hash, key, 123)
+	i, ok := s.tableSet(hash, key, 123)
 	if v := s.list[i].value; !ok || string(v) != string(value) {
 		t.Errorf("foobar should be set to %s: %v %v", value, i, ok)
 	}

--- a/lru_cache.go
+++ b/lru_cache.go
@@ -15,7 +15,7 @@ type LRUCache[K comparable, V any] struct {
 	hasher func(key unsafe.Pointer, seed uintptr) uintptr
 	seed   uintptr
 	loader func(ctx context.Context, key K) (value V, err error)
-	group  singleflight_Group[K, V]
+	group  singleflightGroup[K, V]
 }
 
 // NewLRUCache creates lru cache with size capacity.
@@ -53,7 +53,7 @@ func NewLRUCache[K comparable, V any](size int, options ...Option[K, V]) *LRUCac
 		tablebuckets := make([]uint64, tablesize*(c.mask+1))
 		for i := uint32(0); i <= c.mask; i++ {
 			c.shards[i].list = shardlists[i*(shardsize+1) : (i+1)*(shardsize+1)]
-			c.shards[i].table_buckets = tablebuckets[i*tablesize : (i+1)*tablesize]
+			c.shards[i].tableBuckets = tablebuckets[i*tablesize : (i+1)*tablesize]
 			c.shards[i].Init(shardsize, c.hasher, c.seed)
 		}
 	} else {
@@ -147,10 +147,10 @@ func (c *LRUCache[K, V]) Stats() (stats Stats) {
 	for i := uint32(0); i <= c.mask; i++ {
 		s := &c.shards[i]
 		s.mu.Lock()
-		stats.EntriesCount += uint64(s.table_length)
-		stats.GetCalls += s.stats_getcalls
-		stats.SetCalls += s.stats_setcalls
-		stats.Misses += s.stats_misses
+		stats.EntriesCount += uint64(s.tableLength)
+		stats.GetCalls += s.statsGetCalls
+		stats.SetCalls += s.statsSetCalls
+		stats.Misses += s.statsMisses
 		s.mu.Unlock()
 	}
 	return

--- a/lru_shard_list.go
+++ b/lru_shard_list.go
@@ -6,7 +6,7 @@ import (
 	"unsafe"
 )
 
-func (s *lrushard[K, V]) list_Init(size uint32) {
+func (s *lrushard[K, V]) listInit(size uint32) {
 	size += 1
 	if len(s.list) == 0 {
 		s.list = make([]lrunode[K, V], size)
@@ -17,11 +17,11 @@ func (s *lrushard[K, V]) list_Init(size uint32) {
 	}
 }
 
-func (s *lrushard[K, V]) list_Back() uint32 {
+func (s *lrushard[K, V]) listBack() uint32 {
 	return s.list[0].prev
 }
 
-func (s *lrushard[K, V]) list_MoveToFront(i uint32) {
+func (s *lrushard[K, V]) listMoveToFront(i uint32) {
 	root := &s.list[0]
 	if root.next == i {
 		return
@@ -40,7 +40,7 @@ func (s *lrushard[K, V]) list_MoveToFront(i uint32) {
 	((*lrunode[K, V])(unsafe.Add(base, uintptr(nodei.next)*unsafe.Sizeof(s.list[0])))).prev = i
 }
 
-func (s *lrushard[K, V]) list_MoveToBack(i uint32) {
+func (s *lrushard[K, V]) listMoveToBack(i uint32) {
 	j := s.list[0].prev
 	if i == j {
 		return

--- a/lru_shard_table.go
+++ b/lru_shard_table.go
@@ -17,15 +17,15 @@ const (
 	maxDIB      = ^uint32(0) >> hashBitSize // max 255
 )
 
-func (s *lrushard[K, V]) table_Init(size uint32, hasher func(key unsafe.Pointer, seed uintptr) uintptr, seed uintptr) {
+func (s *lrushard[K, V]) tableInit(size uint32, hasher func(key unsafe.Pointer, seed uintptr) uintptr, seed uintptr) {
 	newsize := lruNewTableSize(size)
-	if len(s.table_buckets) == 0 {
-		s.table_buckets = make([]uint64, newsize)
+	if len(s.tableBuckets) == 0 {
+		s.tableBuckets = make([]uint64, newsize)
 	}
-	s.table_mask = newsize - 1
-	s.table_length = 0
-	s.table_hasher = hasher
-	s.table_seed = seed
+	s.tableMask = newsize - 1
+	s.tableLength = 0
+	s.tableHasher = hasher
+	s.tableSeed = seed
 }
 
 func lruNewTableSize(size uint32) (newsize uint32) {
@@ -41,19 +41,19 @@ func lruNewTableSize(size uint32) (newsize uint32) {
 
 // Set assigns an index to a key.
 // Returns the previous index, or false when no index was assigned.
-func (s *lrushard[K, V]) table_Set(hash uint32, key K, index uint32) (prev uint32, ok bool) {
+func (s *lrushard[K, V]) tableSet(hash uint32, key K, index uint32) (prev uint32, ok bool) {
 	subhash := hash >> dibBitSize
 	hdib := subhash<<dibBitSize | uint32(1)&maxDIB
-	mask := s.table_mask
+	mask := s.tableMask
 	i := (hdib >> dibBitSize) & mask
-	b0 := unsafe.Pointer(&s.table_buckets[0])
+	b0 := unsafe.Pointer(&s.tableBuckets[0])
 	l0 := unsafe.Pointer(&s.list[0])
 	for {
 		b := (*lrubucket)(unsafe.Add(b0, uintptr(i)*8))
 		if b.hdib&maxDIB == 0 {
 			b.hdib = hdib
 			b.index = index
-			s.table_length++
+			s.tableLength++
 			return
 		}
 		if hdib>>dibBitSize == b.hdib>>dibBitSize && (*lrunode[K, V])(unsafe.Add(l0, uintptr(b.index)*unsafe.Sizeof(s.list[0]))).key == key {
@@ -72,13 +72,13 @@ func (s *lrushard[K, V]) table_Set(hash uint32, key K, index uint32) (prev uint3
 	}
 }
 
-// table_Get returns an index for a key.
+// tableGet returns an index for a key.
 // Returns false when no index has been assign for key.
-func (s *lrushard[K, V]) table_Get(hash uint32, key K) (index uint32, ok bool) {
+func (s *lrushard[K, V]) tableGet(hash uint32, key K) (index uint32, ok bool) {
 	subhash := hash >> dibBitSize
-	mask := s.table_mask
+	mask := s.tableMask
 	i := subhash & mask
-	b0 := unsafe.Pointer(&s.table_buckets[0])
+	b0 := unsafe.Pointer(&s.tableBuckets[0])
 	l0 := unsafe.Pointer(&s.list[0])
 	for {
 		b := (*lrubucket)(unsafe.Add(b0, uintptr(i)*8))
@@ -92,13 +92,13 @@ func (s *lrushard[K, V]) table_Get(hash uint32, key K) (index uint32, ok bool) {
 	}
 }
 
-// table_Delete deletes an index for a key.
+// tableDelete deletes an index for a key.
 // Returns the deleted index, or false when no index was assigned.
-func (s *lrushard[K, V]) table_Delete(hash uint32, key K) (index uint32, ok bool) {
+func (s *lrushard[K, V]) tableDelete(hash uint32, key K) (index uint32, ok bool) {
 	subhash := hash >> dibBitSize
-	mask := s.table_mask
+	mask := s.tableMask
 	i := subhash & mask
-	b0 := unsafe.Pointer(&s.table_buckets[0])
+	b0 := unsafe.Pointer(&s.tableBuckets[0])
 	l0 := unsafe.Pointer(&s.list[0])
 	for {
 		b := (*lrubucket)(unsafe.Add(b0, uintptr(i)*8))
@@ -107,16 +107,16 @@ func (s *lrushard[K, V]) table_Delete(hash uint32, key K) (index uint32, ok bool
 		}
 		if b.hdib>>dibBitSize == subhash && (*lrunode[K, V])(unsafe.Add(l0, uintptr(b.index)*unsafe.Sizeof(s.list[0]))).key == key {
 			old := b.index
-			s.table_delete(i)
+			s.tableDeleteByIndex(i)
 			return old, true
 		}
 		i = (i + 1) & mask
 	}
 }
 
-func (s *lrushard[K, V]) table_delete(i uint32) {
-	mask := s.table_mask
-	b0 := unsafe.Pointer(&s.table_buckets[0])
+func (s *lrushard[K, V]) tableDeleteByIndex(i uint32) {
+	mask := s.tableMask
+	b0 := unsafe.Pointer(&s.tableBuckets[0])
 	bi := (*lrubucket)(unsafe.Add(b0, uintptr(i)*8))
 	bi.hdib = bi.hdib>>dibBitSize<<dibBitSize | uint32(0)&maxDIB
 	for {
@@ -132,5 +132,5 @@ func (s *lrushard[K, V]) table_delete(i uint32) {
 		bpi.index = bi.index
 		bpi.hdib = bi.hdib>>dibBitSize<<dibBitSize | (bi.hdib&maxDIB-1)&maxDIB
 	}
-	s.table_length--
+	s.tableLength--
 }

--- a/lru_shard_test.go
+++ b/lru_shard_test.go
@@ -18,11 +18,11 @@ func TestLRUShardListSet(t *testing.T) {
 	s.Init(1024, getRuntimeHasher[string](), 0)
 
 	key := "foobar"
-	hash := uint32(s.table_hasher(noescape(unsafe.Pointer(&key)), s.table_seed))
+	hash := uint32(s.tableHasher(noescape(unsafe.Pointer(&key)), s.tableSeed))
 
 	s.Set(hash, key, 42)
 
-	if index := s.list_Back(); s.list[index].key == key {
+	if index := s.listBack(); s.list[index].key == key {
 		t.Errorf("foobar should be list back: %v %v", index, s.list[index].key)
 	}
 }
@@ -32,11 +32,11 @@ func TestLRUShardTableSet(t *testing.T) {
 	s.Init(1024, getRuntimeHasher[string](), 0)
 
 	key := "foobar"
-	hash := uint32(s.table_hasher(noescape(unsafe.Pointer(&key)), s.table_seed))
+	hash := uint32(s.tableHasher(noescape(unsafe.Pointer(&key)), s.tableSeed))
 
 	s.Set(hash, key, 42)
 
-	i, ok := s.table_Set(hash, key, 123)
+	i, ok := s.tableSet(hash, key, 123)
 	if v := s.list[i].value; !ok || v != 42 {
 		t.Errorf("foobar should be set to 42: %v %v", i, ok)
 	}

--- a/options.go
+++ b/options.go
@@ -97,7 +97,7 @@ func (o *loaderOption[K, V]) applyToLRUCache(c *LRUCache[K, V]) {
 		panic("not_supported")
 	}
 	c.loader = loader
-	c.group = singleflight_Group[K, V]{}
+	c.group = singleflightGroup[K, V]{}
 }
 
 func (o *loaderOption[K, V]) applyToTTLCache(c *TTLCache[K, V]) {
@@ -106,7 +106,7 @@ func (o *loaderOption[K, V]) applyToTTLCache(c *TTLCache[K, V]) {
 		panic("not_supported")
 	}
 	c.loader = loader
-	c.group = singleflight_Group[K, V]{}
+	c.group = singleflightGroup[K, V]{}
 }
 
 func nextPowOf2(n uint32) uint32 {

--- a/ttl_shard_list.go
+++ b/ttl_shard_list.go
@@ -6,7 +6,7 @@ import (
 	"unsafe"
 )
 
-func (s *ttlshard[K, V]) list_Init(size uint32) {
+func (s *ttlshard[K, V]) listInit(size uint32) {
 	size += 1
 	if len(s.list) == 0 {
 		s.list = make([]ttlnode[K, V], size)
@@ -17,11 +17,11 @@ func (s *ttlshard[K, V]) list_Init(size uint32) {
 	}
 }
 
-func (s *ttlshard[K, V]) list_Back() uint32 {
+func (s *ttlshard[K, V]) listBack() uint32 {
 	return s.list[0].prev
 }
 
-func (s *ttlshard[K, V]) list_MoveToFront(i uint32) {
+func (s *ttlshard[K, V]) listMoveToFront(i uint32) {
 	root := &s.list[0]
 	if root.next == i {
 		return
@@ -40,7 +40,7 @@ func (s *ttlshard[K, V]) list_MoveToFront(i uint32) {
 	((*ttlnode[K, V])(unsafe.Add(base, uintptr(nodei.next)*unsafe.Sizeof(s.list[0])))).prev = i
 }
 
-func (s *ttlshard[K, V]) list_MoveToBack(i uint32) {
+func (s *ttlshard[K, V]) listMoveToBack(i uint32) {
 	j := s.list[0].prev
 	if i == j {
 		return

--- a/ttl_shard_table.go
+++ b/ttl_shard_table.go
@@ -9,15 +9,15 @@ import (
 	"unsafe"
 )
 
-func (s *ttlshard[K, V]) table_Init(size uint32, hasher func(key unsafe.Pointer, seed uintptr) uintptr, seed uintptr) {
+func (s *ttlshard[K, V]) tableInit(size uint32, hasher func(key unsafe.Pointer, seed uintptr) uintptr, seed uintptr) {
 	newsize := ttlNewTableSize(size)
-	if len(s.table_buckets) == 0 {
-		s.table_buckets = make([]uint64, newsize)
+	if len(s.tableBuckets) == 0 {
+		s.tableBuckets = make([]uint64, newsize)
 	}
-	s.table_mask = newsize - 1
-	s.table_length = 0
-	s.table_hasher = hasher
-	s.table_seed = seed
+	s.tableMask = newsize - 1
+	s.tableLength = 0
+	s.tableHasher = hasher
+	s.tableSeed = seed
 }
 
 func ttlNewTableSize(size uint32) (newsize uint32) {
@@ -31,21 +31,21 @@ func ttlNewTableSize(size uint32) (newsize uint32) {
 	return
 }
 
-// table_Set assigns an index to a key.
+// tableSet assigns an index to a key.
 // Returns the previous index, or false when no index was assigned.
-func (s *ttlshard[K, V]) table_Set(hash uint32, key K, index uint32) (prev uint32, ok bool) {
+func (s *ttlshard[K, V]) tableSet(hash uint32, key K, index uint32) (prev uint32, ok bool) {
 	subhash := hash >> dibBitSize
 	hdib := subhash<<dibBitSize | uint32(1)&maxDIB
-	mask := s.table_mask
+	mask := s.tableMask
 	i := (hdib >> dibBitSize) & mask
-	b0 := unsafe.Pointer(&s.table_buckets[0])
+	b0 := unsafe.Pointer(&s.tableBuckets[0])
 	l0 := unsafe.Pointer(&s.list[0])
 	for {
 		b := (*ttlbucket)(unsafe.Add(b0, uintptr(i)*8))
 		if b.hdib&maxDIB == 0 {
 			b.hdib = hdib
 			b.index = index
-			s.table_length++
+			s.tableLength++
 			return
 		}
 		if hdib>>dibBitSize == b.hdib>>dibBitSize && (*ttlnode[K, V])(unsafe.Add(l0, uintptr(b.index)*unsafe.Sizeof(s.list[0]))).key == key {
@@ -64,13 +64,13 @@ func (s *ttlshard[K, V]) table_Set(hash uint32, key K, index uint32) (prev uint3
 	}
 }
 
-// table_Get returns an index for a key.
+// tableGet returns an index for a key.
 // Returns false when no index has been assign for key.
-func (s *ttlshard[K, V]) table_Get(hash uint32, key K) (index uint32, ok bool) {
+func (s *ttlshard[K, V]) tableGet(hash uint32, key K) (index uint32, ok bool) {
 	subhash := hash >> dibBitSize
-	mask := s.table_mask
+	mask := s.tableMask
 	i := subhash & mask
-	b0 := unsafe.Pointer(&s.table_buckets[0])
+	b0 := unsafe.Pointer(&s.tableBuckets[0])
 	l0 := unsafe.Pointer(&s.list[0])
 	for {
 		b := (*ttlbucket)(unsafe.Add(b0, uintptr(i)*8))
@@ -84,13 +84,13 @@ func (s *ttlshard[K, V]) table_Get(hash uint32, key K) (index uint32, ok bool) {
 	}
 }
 
-// table_Delete deletes an index for a key.
+// tableDelete deletes an index for a key.
 // Returns the deleted index, or false when no index was assigned.
-func (s *ttlshard[K, V]) table_Delete(hash uint32, key K) (v uint32, ok bool) {
+func (s *ttlshard[K, V]) tableDelete(hash uint32, key K) (v uint32, ok bool) {
 	subhash := hash >> dibBitSize
-	mask := s.table_mask
+	mask := s.tableMask
 	i := subhash & mask
-	b0 := unsafe.Pointer(&s.table_buckets[0])
+	b0 := unsafe.Pointer(&s.tableBuckets[0])
 	l0 := unsafe.Pointer(&s.list[0])
 	for {
 		b := (*ttlbucket)(unsafe.Add(b0, uintptr(i)*8))
@@ -99,16 +99,16 @@ func (s *ttlshard[K, V]) table_Delete(hash uint32, key K) (v uint32, ok bool) {
 		}
 		if b.hdib>>dibBitSize == subhash && (*ttlnode[K, V])(unsafe.Add(l0, uintptr(b.index)*unsafe.Sizeof(s.list[0]))).key == key {
 			old := b.index
-			s.table_delete(i)
+			s.tableDeleteByIndex(i)
 			return old, true
 		}
 		i = (i + 1) & mask
 	}
 }
 
-func (s *ttlshard[K, V]) table_delete(i uint32) {
-	mask := s.table_mask
-	b0 := unsafe.Pointer(&s.table_buckets[0])
+func (s *ttlshard[K, V]) tableDeleteByIndex(i uint32) {
+	mask := s.tableMask
+	b0 := unsafe.Pointer(&s.tableBuckets[0])
 	bi := (*ttlbucket)(unsafe.Add(b0, uintptr(i)*8))
 	bi.hdib = bi.hdib>>dibBitSize<<dibBitSize | uint32(0)&maxDIB
 	for {
@@ -124,5 +124,5 @@ func (s *ttlshard[K, V]) table_delete(i uint32) {
 		bpi.index = bi.index
 		bpi.hdib = bi.hdib>>dibBitSize<<dibBitSize | (bi.hdib&maxDIB-1)&maxDIB
 	}
-	s.table_length--
+	s.tableLength--
 }

--- a/ttl_shard_test.go
+++ b/ttl_shard_test.go
@@ -18,11 +18,11 @@ func TestTTLShardListSet(t *testing.T) {
 	s.Init(1024, getRuntimeHasher[string](), 0)
 
 	key := "foobar"
-	hash := uint32(s.table_hasher(noescape(unsafe.Pointer(&key)), s.table_seed))
+	hash := uint32(s.tableHasher(noescape(unsafe.Pointer(&key)), s.tableSeed))
 
 	s.Set(hash, key, 42, 0)
 
-	if index := s.list_Back(); s.list[index].key == key {
+	if index := s.listBack(); s.list[index].key == key {
 		t.Errorf("foobar should be list back: %v %v", index, s.list[index].key)
 	}
 }
@@ -32,11 +32,11 @@ func TestTTLShardTableSet(t *testing.T) {
 	s.Init(1024, getRuntimeHasher[string](), 0)
 
 	key := "foobar"
-	hash := uint32(s.table_hasher(noescape(unsafe.Pointer(&key)), s.table_seed))
+	hash := uint32(s.tableHasher(noescape(unsafe.Pointer(&key)), s.tableSeed))
 
 	s.Set(hash, key, 42, 0)
 
-	i, ok := s.table_Set(hash, key, 123)
+	i, ok := s.tableSet(hash, key, 123)
 	if v := s.list[i].value; !ok || v != 42 {
 		t.Errorf("foobar should be set to 42: %v %v", i, ok)
 	}


### PR DESCRIPTION
## Description

According to go language specification we should use camel case instead of snake case, this PR switches some field names and method names to camel case format, please let me know if its accessible or need to update more.
