### PR TITLE
[wip]fix: zero value may cause incorrect length

### DIFF
--- a/ttl_cache_test.go
+++ b/ttl_cache_test.go
@@ -403,6 +403,31 @@ func TestTTLCacheStats(t *testing.T) {
 	}
 }
 
+func TestGetLength(t *testing.T) {
+	cache := NewTTLCache[int, int](1024)
+
+	for i := 0; i < 1000; i++ {
+		cache.Set(i, i, time.Hour)
+	}
+
+	if got, want := cache.Len(), 1000; got != want {
+		t.Fatalf("bad cache length, got %v, want %v", got, want)
+	}
+}
+
+//func TestGetLengthWithString(t *testing.T) {
+//	cache := NewTTLCache[string, string](1024)
+//
+//	for i := 0; i < 1024; i++ {
+//		s := fmt.Sprintf("hello-%d", i)
+//		cache.Set(s, s, time.Hour)
+//	}
+//
+//	if got, want := cache.Len(), 1024; got != want {
+//		t.Fatalf("bad cache length, got %v, want %v", got, want)
+//	}
+//}
+
 func BenchmarkTTLCacheRand(b *testing.B) {
 	cache := NewTTLCache[int64, int64](8192)
 


### PR DESCRIPTION
# Description

fix #17

but it still not work with `string` or something else like below:

```go
func TestGetLengthWithString(t *testing.T) {
	cache := NewTTLCache[string, string](1024)

	for i := 0; i < 1024; i++ {
		s := fmt.Sprintf("hello-%d", i)
		cache.Set(s, s, time.Hour)
	}

	if got, want := cache.Len(), 1024; got != want {
		t.Fatalf("bad cache length, got %v, want %v", got, want)
	}
}

//     ttl_cache_test.go:427: bad cache length, got 827, want 1024
```

@phuslu any suggestion on this? thanks.